### PR TITLE
Remove some parsing errors

### DIFF
--- a/ass2srt/ass2srt.py
+++ b/ass2srt/ass2srt.py
@@ -27,6 +27,7 @@ class Ass2srt:
                 node = line.split(",")
                 node[1] = timefmt(node[1])
                 node[2] = timefmt(node[2])
+                node[9] = ",".join(node[9:])
                 node[9] = re.sub(r'{[^}]*}', "", node[9]).strip()
                 node[9] = re.sub(r'\\N', "\n", node[9])
                 self.nodes.append(node)

--- a/ass2srt/ass2srt.py
+++ b/ass2srt/ass2srt.py
@@ -27,7 +27,7 @@ class Ass2srt:
                 node = line.split(",")
                 node[1] = timefmt(node[1])
                 node[2] = timefmt(node[2])
-                node[9] = re.sub(r'{.*}', "", node[9]).strip()
+                node[9] = re.sub(r'{[^}]*}', "", node[9]).strip()
                 node[9] = re.sub(r'\\N', "\n", node[9])
                 self.nodes.append(node)
                 # print(f"{node[1]}-->{node[2]}:{node[9]}\n")


### PR DESCRIPTION
There were two problems in the Dialogue parser:

* the markup removal was greedy, so `a {} b {} c` was substitued into `a c` instead of `a b c`
* the splitting with `,` did not take into account that text could also contain a `,`

This commit fixes the two problems